### PR TITLE
uncaught issue would crash server on authorized route

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,9 +36,13 @@ internals.implementation = function (server, options) {
         return reply(Boom.unauthorized(null, 'Signature'));
       }
 
-      var parsedSignature = HttpSignature.parseRequest(req);
-      if (!parsedSignature) {
-        return reply(Boom.unauthorized('HTTP authentication header missing signature', 'Signature'));
+      try {
+        var parsedSignature = HttpSignature.parseRequest(req);
+        if (!parsedSignature) {
+          return reply(Boom.unauthorized('HTTP authentication header missing signature'));
+        }
+      } catch (e) {
+		  return reply(Boom.badRequest(e, 'Signature'));
       }
 
       settings.validateFunc(request, parsedSignature, function (err, isValid, credentials) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ internals.implementation = function (server, options) {
           return reply(Boom.unauthorized('HTTP authentication header missing signature'));
         }
       } catch (e) {
-		  return reply(Boom.badRequest(e, 'Signature'));
+          return reply(Boom.badRequest(e, 'Signature'));
       }
 
       settings.validateFunc(request, parsedSignature, function (err, isValid, credentials) {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Anthony Bouch <tony@58bits.com> (http://www.58bits.com)",
   "repository":
     {
-      "type": "git",
-      "url": "git://github.com/58bits/hapi-auth-signature"
+      "type": "git"
+	  ,"url": "git://github.com/58bits/hapi-auth-signature"
     },
   "main": "index",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,39 +1,36 @@
 {
-  "name": "hapi-auth-signature",
-  "description": "Signature authentication plugin that wraps https://github.com/joyent/node-http-signature",
-  "version": "2.1.1",
-  "author": "Anthony Bouch <tony@58bits.com> (http://www.58bits.com)",
-  "repository":
-    {
-      "type": "git"
-      ,"url": "git://github.com/58bits/hapi-auth-signature"
-    },
-  "main": "index",
-  "keywords": [
-    "hapi",
-    "plugin",
-    "auth",
-    "signature"
-  ],
-  "engines": {
-    "node": ">=0.10.32"
-  },
-  "dependencies": {
-    "boom": "2.x.x",
-    "hoek": "2.x.x",
-    "http-signature": "0.11.*"
-  },
-  "peerDependencies": {
-    "hapi": ">=8.x.x"
-  },
-  "devDependencies": {
-    "hapi": "8.x.x",
-    "lab": "5.x.x"
-  },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/58bits/hapi-auth-signature/raw/master/LICENSE"
-    }
-  ]
+	"name": "hapi-auth-signature",
+	"description": "Signature authentication plugin that wraps https://github.com/joyent/node-http-signature",
+	"version": "2.1.2",
+	"author": "Anthony Bouch <tony@58bits.com> (http://www.58bits.com)",
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/58bits/hapi-auth-signature"
+	},
+	"main": "index",
+	"keywords": [
+		"hapi",
+		"plugin",
+		"auth",
+		"signature"
+	],
+	"engines": {
+		"node": ">=0.10.32"
+	},
+	"dependencies": {
+		"boom": "2.x.x",
+		"hoek": "2.x.x",
+		"http-signature": "0.11.*"
+	},
+	"peerDependencies": {
+		"hapi": ">=8.x.x"
+	},
+	"devDependencies": {
+		"hapi": "8.x.x",
+		"lab": "5.x.x"
+	},
+	"licenses": [{
+		"type": "BSD",
+		"url": "http://github.com/58bits/hapi-auth-signature/raw/master/LICENSE"
+	}]
 }

--- a/package.json
+++ b/package.json
@@ -1,36 +1,36 @@
 {
-	"name": "hapi-auth-signature",
-	"description": "Signature authentication plugin that wraps https://github.com/joyent/node-http-signature",
-	"version": "2.1.2",
-	"author": "Anthony Bouch <tony@58bits.com> (http://www.58bits.com)",
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/58bits/hapi-auth-signature"
-	},
-	"main": "index",
-	"keywords": [
-		"hapi",
-		"plugin",
-		"auth",
-		"signature"
-	],
-	"engines": {
-		"node": ">=0.10.32"
-	},
-	"dependencies": {
-		"boom": "2.x.x",
-		"hoek": "2.x.x",
-		"http-signature": "0.11.*"
-	},
-	"peerDependencies": {
-		"hapi": ">=8.x.x"
-	},
-	"devDependencies": {
-		"hapi": "8.x.x",
-		"lab": "5.x.x"
-	},
-	"licenses": [{
-		"type": "BSD",
-		"url": "http://github.com/58bits/hapi-auth-signature/raw/master/LICENSE"
-	}]
+  "name": "hapi-auth-signature",
+  "description": "Signature authentication plugin that wraps https://github.com/joyent/node-http-signature",
+  "version": "2.1.2",
+  "author": "Anthony Bouch <tony@58bits.com> (http://www.58bits.com)",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/58bits/hapi-auth-signature"
+  },
+  "main": "index",
+  "keywords": [
+    "hapi",
+    "plugin",
+    "auth",
+    "signature"
+  ],
+  "engines": {
+    "node": ">=0.10.32"
+  },
+  "dependencies": {
+    "boom": "2.x.x",
+    "hoek": "2.x.x",
+    "http-signature": "0.11.*"
+  },
+  "peerDependencies": {
+    "hapi": ">=8.x.x"
+  },
+  "devDependencies": {
+    "hapi": "8.x.x",
+    "lab": "5.x.x"
+  },
+  "licenses": [{
+    "type": "BSD",
+    "url": "http://github.com/58bits/hapi-auth-signature/raw/master/LICENSE"
+  }]
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository":
     {
       "type": "git"
-	  ,"url": "git://github.com/58bits/hapi-auth-signature"
+      ,"url": "git://github.com/58bits/hapi-auth-signature"
     },
   "main": "index",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "description": "Signature authentication plugin that wraps https://github.com/joyent/node-http-signature",
   "version": "2.1.2",
   "author": "Anthony Bouch <tony@58bits.com> (http://www.58bits.com)",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/58bits/hapi-auth-signature"
-  },
+  "repository":
+    {
+      "type": "git",
+      "url": "git://github.com/58bits/hapi-auth-signature"
+    },
   "main": "index",
   "keywords": [
     "hapi",
@@ -29,8 +30,10 @@
     "hapi": "8.x.x",
     "lab": "5.x.x"
   },
-  "licenses": [{
-    "type": "BSD",
-    "url": "http://github.com/58bits/hapi-auth-signature/raw/master/LICENSE"
-  }]
+  "licenses": [
+    {
+      "type": "BSD",
+      "url": "http://github.com/58bits/hapi-auth-signature/raw/master/LICENSE"
+    }
+  ]
 }


### PR DESCRIPTION
The old response was a 500 internal server error as the parse was throwing errors. Added in a try catch to at least present something to the caller rather a potential crash.

Response:

``` javascript
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "ExpiredRequestError: clock skew of 2858.434s was greater than 300s"
}
```
