### PR TITLE
Added options to object returned by implementation so that payload va…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,7 @@ internals.implementation = function (server, options) {
   var settings = Hoek.clone(options);
 
   var scheme = {
+    options: options,
     authenticate: function (request, reply) {
 
       var req = request.raw.req;


### PR DESCRIPTION
…lidation can be turned on

Since the only properties currently used from options are the payloadFunc and validateFunc, payload validation can not be set to required for the plugin as a whole, but only on a route by route basis. 